### PR TITLE
Allow the term "Mastercard"

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -2561,6 +2561,7 @@ Naming/InclusiveLanguage:
       AllowedRegex:
         - 'Master of None'
         - 'Master Boot Record'
+        - 'Mastercard'
     slave:
       Suggestions: ['replica', 'secondary', 'follower']
 


### PR DESCRIPTION
The new cop marks the term "Mastercard" as offensive. 

Although they should rename the company to Maincard, that's not going to happen soon.

This PR allows the term Mastercard by default.
